### PR TITLE
[FIX] Required isCoreLibraryDesugaringEnabled

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -23,7 +23,7 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        coreLibraryDesugaringEnabled = true 
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }


### PR DESCRIPTION
Change  coreLibraryDesugaringEnabled to isCoreLibraryDesugaringEnabled, which is the proper syntax for Gradle Kotlin DSL.