### PR TITLE
[FIX] desugar_jdk_libs version

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -72,5 +72,5 @@ flutter {
 }
 
 dependencies {
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }


### PR DESCRIPTION
The desugar_jdk_libs version has been updated from 2.0.4 to 2.1.4 to meet the requirement of flutter_local_notifications.